### PR TITLE
Set GOMAXPROCS to match Linux container CPU quota with automaxprocs

### DIFF
--- a/cmd/redirector/main.go
+++ b/cmd/redirector/main.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+
+	_ "go.uber.org/automaxprocs"
 )
 
 var version, gitcommit string

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/livesense-inc/go-simple-http-redirector
 
 go 1.21.7
+
+require go.uber.org/automaxprocs v1.5.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+go.uber.org/automaxprocs v1.5.3 h1:kWazyxZUrS3Gs4qUpbwo5kEIMGe/DAvi5Z4tl2NW4j8=
+go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnwa1WM0=


### PR DESCRIPTION
The redirector must run on some container service. So, I set GOMAXPROCS with [uber-go/automaxprocs](https://github.com/uber-go/automaxprocs)